### PR TITLE
Web Feature ID: `fullscreen` generated tests

### DIFF
--- a/fullscreen/api/close-request-fully-exit-fullscreen.html
+++ b/fullscreen/api/close-request-fully-exit-fullscreen.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Fullscreen takes precedence over close watchers for close requests</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#fully-exit-fullscreen">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#close-requests-and-close-watchers">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/close-watcher/resources/helpers.js"></script>
+
+<div id="target" style="width: 10px; height: 10px;"></div>
+
+<script>
+for (const type of ['CloseWatcher', 'dialog', 'popover']) {
+  promise_test(async t => {
+    const target = document.querySelector('#target');
+
+    // 1. Enter fullscreen
+    await test_driver.bless("request fullscreen");
+    await target.requestFullscreen();
+    assert_equals(document.fullscreenElement, target, "Fullscreen should be entered");
+
+    // Ensure we always clean up fullscreen state
+    t.add_cleanup(async () => {
+      if (document.fullscreenElement) {
+        await document.exitFullscreen().catch(() => {});
+      }
+    });
+
+    // 2. Create the close watcher
+    const events = [];
+    createRecordingCloseWatcher(t, events, 'watcher', type);
+
+    let fullscreenExited = false;
+    const onFullscreenChange = () => {
+      if (!document.fullscreenElement) {
+        fullscreenExited = true;
+      }
+    };
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+    t.add_cleanup(() => document.removeEventListener('fullscreenchange', onFullscreenChange));
+
+    // 3. Send close request
+    await sendCloseRequest();
+    await waitForPotentialCloseEvent();
+    await new Promise(resolve => t.step_timeout(resolve, 100));
+
+    // 4. Assertions
+    assert_true(fullscreenExited, "Fullscreen should have exited");
+    assert_equals(document.fullscreenElement, null, "Fullscreen should be fully exited");
+    assert_array_equals(events, [], `${type} should not receive close request because fullscreen took precedence`);
+  }, `Close request exits fullscreen, taking precedence over ${type}`);
+}
+</script>

--- a/fullscreen/api/document-exit-fullscreen-active-document.html
+++ b/fullscreen/api/document-exit-fullscreen-active-document.html
@@ -2,6 +2,7 @@
 <title>
     Document#exitFullscreen() when the document is not the active document
 </title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
@@ -20,8 +21,8 @@
         await promise_rejects_js(
             t,
             stolenTypeError,
-            documentBeforeNav.documentElement.requestFullscreen(),
-            "Promise should be undefined after navigation"
+            documentBeforeNav.exitFullscreen(),
+            "Promise should reject with TypeError when document is not fully active"
         );
     });
 </script>

--- a/fullscreen/api/document-exit-fullscreen-unlock-screen-orientation.html
+++ b/fullscreen/api/document-exit-fullscreen-unlock-screen-orientation.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Fullscreen API: Document#exitFullscreen() unlocks screen orientation</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="module">
+  import {
+    getOppositeOrientation,
+    makeCleanup,
+  } from "/screen-orientation/resources/orientation-utils.js";
+
+  promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
+
+    // Call lock() which returns a promise.
+    const lockPromise = screen.orientation.lock(getOppositeOrientation());
+
+    // Exit fullscreen should trigger "fully unlock the screen orientation".
+    const fsExitPromise = document.exitFullscreen();
+
+    // "fully unlock" aborts any pending lock request with an AbortError.
+    await promise_rejects_dom(t, "AbortError", lockPromise);
+    await fsExitPromise;
+  }, "exitFullscreen() aborts a pending screen orientation lock request");
+</script>

--- a/fullscreen/api/document-fullscreen.html
+++ b/fullscreen/api/document-fullscreen.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Document#fullscreen</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<body>
+<script>
+promise_test(async function(t) {
+  const div = document.createElement("div");
+  document.body.appendChild(div);
+  t.add_cleanup(() => div.remove());
+
+  assert_equals(document.fullscreenElement, null, "fullscreenElement should initially be null");
+  assert_false(document.fullscreen, "document.fullscreen must be false when fullscreenElement is null");
+
+  await Promise.all([trusted_request(div), fullScreenChange()]);
+
+  assert_equals(document.fullscreenElement, div, "fullscreenElement should be the div after entering fullscreen");
+  assert_true(document.fullscreen, "document.fullscreen must be true when fullscreenElement is not null");
+
+  const exitPromise = document.exitFullscreen();
+  await Promise.all([exitPromise, fullScreenChange()]);
+
+  assert_equals(document.fullscreenElement, null, "fullscreenElement should be null after exiting fullscreen");
+  assert_false(document.fullscreen, "document.fullscreen must be false when fullscreenElement is null");
+
+}, "document.fullscreen must return true if document.fullscreenElement is not null, and false otherwise");
+</script>

--- a/fullscreen/api/element-onfullscreenchange.html
+++ b/fullscreen/api/element-onfullscreenchange.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Element must not support onfullscreenchange event handler content attribute in any namespace</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script>
+window.handlerExecuted = false;
+
+const namespaces = [
+  { name: "HTML", ns: "http://www.w3.org/1999/xhtml", elemName: "div" },
+  { name: "SVG", ns: "http://www.w3.org/2000/svg", elemName: "svg" },
+  { name: "MathML", ns: "http://www.w3.org/1998/Math/MathML", elemName: "math" },
+  { name: "null", ns: null, elemName: "element" },
+  { name: "unknown", ns: "https://unknown.namespace", elemName: "element" },
+  { name: "empty", ns: "", elemName: "element" }
+];
+
+for (const { name, ns, elemName } of namespaces) {
+  test(t => {
+    t.add_cleanup(() => { window.handlerExecuted = false; });
+    let element = document.createElementNS(ns, elemName);
+    element.setAttribute("onfullscreenchange", "window.handlerExecuted = true;");
+
+    element.dispatchEvent(new Event("fullscreenchange", { bubbles: true, cancelable: true }));
+    assert_false(window.handlerExecuted, `The handler should not execute for ${name} namespace.`);
+    assert_equals(element.onfullscreenchange, null, `The IDL attribute should not be populated by the content attribute for ${name} namespace.`);
+  }, `Element in ${name} namespace does not support onfullscreenchange event handler content attribute`);
+}
+</script>

--- a/fullscreen/api/element-onfullscreenerror.html
+++ b/fullscreen/api/element-onfullscreenerror.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Element must not support onfullscreenerror event handler content attribute in any namespace</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script>
+window.handlerExecuted = false;
+
+const namespaces = [
+  { name: "HTML", ns: "http://www.w3.org/1999/xhtml", elemName: "div" },
+  { name: "SVG", ns: "http://www.w3.org/2000/svg", elemName: "svg" },
+  { name: "MathML", ns: "http://www.w3.org/1998/Math/MathML", elemName: "math" },
+  { name: "null", ns: null, elemName: "element" },
+  { name: "unknown", ns: "https://unknown.namespace", elemName: "element" },
+  { name: "empty", ns: "", elemName: "element" }
+];
+
+for (const { name, ns, elemName } of namespaces) {
+  test(t => {
+    t.add_cleanup(() => { window.handlerExecuted = false; });
+    let element = document.createElementNS(ns, elemName);
+    element.setAttribute("onfullscreenerror", "window.handlerExecuted = true;");
+
+    element.dispatchEvent(new Event("fullscreenerror", { bubbles: true, cancelable: true }));
+    assert_false(window.handlerExecuted, `The handler should not execute for ${name} namespace.`);
+    assert_equals(element.onfullscreenerror, null, `The IDL attribute should not be populated by the content attribute for ${name} namespace.`);
+  }, `Element in ${name} namespace does not support onfullscreenerror event handler content attribute`);
+}
+</script>

--- a/fullscreen/api/element-request-fullscreen-and-popovers.window.js
+++ b/fullscreen/api/element-request-fullscreen-and-popovers.window.js
@@ -1,0 +1,166 @@
+// META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
+// Spec: https://fullscreen.spec.whatwg.org/
+
+const customCleanup = async () => {
+  if (document.fullscreenElement) {
+    await document.exitFullscreen();
+  }
+};
+
+const testCases = [
+  {
+    desc: 'Fullscreen element outside of auto popover',
+    setup: (t) => {
+      const p1 = document.createElement('div');
+      p1.popover = 'auto';
+      document.body.appendChild(p1);
+      t.add_cleanup(() => p1.remove());
+
+      const fs = document.createElement('div');
+      document.body.appendChild(fs);
+      t.add_cleanup(() => fs.remove());
+
+      p1.showPopover();
+      return { popovers: [{ element: p1, expectOpen: false }], fs };
+    }
+  },
+  {
+    desc: 'Fullscreen element outside of manual popover',
+    setup: (t) => {
+      const p1 = document.createElement('div');
+      p1.popover = 'manual';
+      document.body.appendChild(p1);
+      t.add_cleanup(() => p1.remove());
+
+      const fs = document.createElement('div');
+      document.body.appendChild(fs);
+      t.add_cleanup(() => fs.remove());
+
+      p1.showPopover();
+      return { popovers: [{ element: p1, expectOpen: true }], fs };
+    }
+  },
+  {
+    desc: 'Fullscreen element inside of auto popover',
+    setup: (t) => {
+      const p1 = document.createElement('div');
+      p1.popover = 'auto';
+      document.body.appendChild(p1);
+      t.add_cleanup(() => p1.remove());
+
+      const fs = document.createElement('div');
+      p1.appendChild(fs);
+
+      p1.showPopover();
+      return { popovers: [{ element: p1, expectOpen: true }], fs };
+    }
+  },
+  {
+    desc: 'Fullscreen element inside of manual popover',
+    setup: (t) => {
+      const p1 = document.createElement('div');
+      p1.popover = 'manual';
+      document.body.appendChild(p1);
+      t.add_cleanup(() => p1.remove());
+
+      const fs = document.createElement('div');
+      p1.appendChild(fs);
+
+      p1.showPopover();
+      return { popovers: [{ element: p1, expectOpen: true }], fs };
+    }
+  },
+  {
+    desc: 'Fullscreen element inside ancestor popover, with sibling auto popover',
+    setup: (t) => {
+      const p1 = document.createElement('div');
+      p1.popover = 'auto';
+      document.body.appendChild(p1);
+      t.add_cleanup(() => p1.remove());
+
+      const p2 = document.createElement('div');
+      p2.popover = 'auto';
+      p1.appendChild(p2);
+
+      const fs = document.createElement('div');
+      p1.appendChild(fs);
+
+      p1.showPopover();
+      p2.showPopover();
+      return { popovers: [
+        { element: p1, expectOpen: true },
+        { element: p2, expectOpen: false }
+      ], fs };
+    }
+  },
+  {
+    desc: 'Fullscreen element inside ancestor popover, with sibling manual popover',
+    setup: (t) => {
+      const p1 = document.createElement('div');
+      p1.popover = 'auto';
+      document.body.appendChild(p1);
+      t.add_cleanup(() => p1.remove());
+
+      const p2 = document.createElement('div');
+      p2.popover = 'manual';
+      p1.appendChild(p2);
+
+      const fs = document.createElement('div');
+      p1.appendChild(fs);
+
+      p1.showPopover();
+      p2.showPopover();
+      return { popovers: [
+        { element: p1, expectOpen: true },
+        { element: p2, expectOpen: true }
+      ], fs };
+    }
+  },
+  {
+    desc: 'Fullscreen element inside nested auto popovers',
+    setup: (t) => {
+      const p1 = document.createElement('div');
+      p1.popover = 'auto';
+      document.body.appendChild(p1);
+      t.add_cleanup(() => p1.remove());
+
+      const p2 = document.createElement('div');
+      p2.popover = 'auto';
+      p1.appendChild(p2);
+
+      const fs = document.createElement('div');
+      p2.appendChild(fs);
+
+      p1.showPopover();
+      p2.showPopover();
+      return { popovers: [
+        { element: p1, expectOpen: true },
+        { element: p2, expectOpen: true }
+      ], fs };
+    }
+  }
+];
+
+for (const { desc, setup } of testCases) {
+  promise_test(async (t) => {
+    t.add_cleanup(customCleanup);
+    const { popovers, fs } = setup(t);
+
+    for (let i = 0; i < popovers.length; i++) {
+      assert_true(popovers[i].element.matches(':popover-open'), `popover ${i + 1} should be initially open`);
+    }
+
+    await test_driver.bless("request fullscreen");
+    await fs.requestFullscreen();
+
+    for (let i = 0; i < popovers.length; i++) {
+      const { element, expectOpen } = popovers[i];
+      if (expectOpen) {
+        assert_true(element.matches(':popover-open'), `popover ${i + 1} should remain open`);
+      } else {
+        assert_false(element.matches(':popover-open'), `popover ${i + 1} should be closed`);
+      }
+    }
+  }, desc);
+}

--- a/fullscreen/api/element-request-fullscreen-not-supported.html
+++ b/fullscreen/api/element-request-fullscreen-not-supported.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<title>Element#requestFullscreen() when fullscreen is not supported</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<div id="log"></div>
+<iframe id="test-frame" allow="fullscreen 'none'"></iframe>
+<script>
+promise_test(async (t) => {
+  const iframe = document.getElementById("test-frame");
+  const iframeDoc = iframe.contentDocument;
+  const div = iframeDoc.createElement("div");
+  iframeDoc.body.appendChild(div);
+
+  assert_false(iframeDoc.fullscreenEnabled, "fullscreenEnabled should be false in iframe with allow=\"fullscreen 'none'\"");
+
+  const errorEventPromise = new Promise(resolve => {
+    iframeDoc.onfullscreenerror = resolve;
+  });
+
+  const action = () => {
+    return promise_rejects_js(t, iframeDoc.defaultView.TypeError, div.requestFullscreen());
+  };
+
+  const [event] = await Promise.all([
+    errorEventPromise,
+    test_driver.bless("request full screen", action, iframe.contentWindow)
+  ]);
+
+  assert_equals(event.type, "fullscreenerror");
+  assert_equals(event.target, div, "event.target should be the element");
+  assert_true(event.bubbles, "event.bubbles");
+  assert_false(event.cancelable, "event.cancelable");
+  assert_true(event.composed, "event.composed");
+}, "requestFullscreen() when fullscreen is not supported");
+</script>

--- a/fullscreen/api/shadowroot-fullscreen-element-disconnected.window.js
+++ b/fullscreen/api/shadowroot-fullscreen-element-disconnected.window.js
@@ -1,0 +1,22 @@
+// META: title=ShadowRoot.fullscreenElement on disconnected host
+// https://fullscreen.spec.whatwg.org/
+
+test(() => {
+  const host = document.createElement("div");
+  const shadow = host.attachShadow({ mode: "open" });
+  assert_equals(shadow.fullscreenElement, null);
+}, "fullscreenElement accessed on an open shadow root whose host is not connected to the DOM must return null.");
+
+test(() => {
+  const host = document.createElement("div");
+  const shadow = host.attachShadow({ mode: "closed" });
+  assert_equals(shadow.fullscreenElement, null);
+}, "fullscreenElement accessed on a closed shadow root whose host is not connected to the DOM must return null.");
+
+test(() => {
+  const parent = document.createElement("div");
+  const host = document.createElement("div");
+  parent.appendChild(host);
+  const shadow = host.attachShadow({ mode: "open" });
+  assert_equals(shadow.fullscreenElement, null);
+}, "fullscreenElement accessed on a shadow root whose host is in a disconnected tree must return null.");

--- a/fullscreen/api/shadowroot-onfullscreenchange.html
+++ b/fullscreen/api/shadowroot-onfullscreenchange.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>ShadowRoot interface must not support the onfullscreenchange event handler IDL attribute</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  const div = document.createElement("div");
+  const shadowRoot = div.attachShadow({ mode: "open" });
+  assert_false("onfullscreenchange" in shadowRoot, "onfullscreenchange should not be present on ShadowRoot instances");
+  assert_false("onfullscreenchange" in ShadowRoot.prototype, "onfullscreenchange should not be present on ShadowRoot.prototype");
+}, "The ShadowRoot interface must not support the onfullscreenchange event handler IDL attribute");
+</script>

--- a/fullscreen/api/shadowroot-onfullscreenerror.html
+++ b/fullscreen/api/shadowroot-onfullscreenerror.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>ShadowRoot interface must not support the onfullscreenerror event handler IDL attribute</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  const div = document.createElement("div");
+  const shadowRoot = div.attachShadow({ mode: "open" });
+  assert_false("onfullscreenerror" in shadowRoot, "onfullscreenerror should not be present on ShadowRoot instances");
+  assert_false("onfullscreenerror" in ShadowRoot.prototype, "onfullscreenerror should not be present on ShadowRoot.prototype");
+}, "The ShadowRoot interface must not support the onfullscreenerror event handler IDL attribute");
+</script>

--- a/fullscreen/api/window-onfullscreenchange.html
+++ b/fullscreen/api/window-onfullscreenchange.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Window interface must not support the onfullscreenchange event handler IDL attribute</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_false("onfullscreenchange" in window, "onfullscreenchange should not be present on Window instances");
+  assert_false("onfullscreenchange" in Window.prototype, "onfullscreenchange should not be present on Window.prototype");
+}, "The Window interface must not support the onfullscreenchange event handler IDL attribute");
+</script>

--- a/fullscreen/api/window-onfullscreenerror.html
+++ b/fullscreen/api/window-onfullscreenerror.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Window interface must not support the onfullscreenerror event handler IDL attribute</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_false("onfullscreenerror" in window, "onfullscreenerror should not be present on Window instances");
+  assert_false("onfullscreenerror" in Window.prototype, "onfullscreenerror should not be present on Window.prototype");
+}, "The Window interface must not support the onfullscreenerror event handler IDL attribute");
+</script>

--- a/fullscreen/model/unload-document-cleanup.html
+++ b/fullscreen/model/unload-document-cleanup.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<title>Fullscreen: exiting fullscreen when a document unloads</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<iframe allowfullscreen></iframe>
+<script>
+promise_test(async (t) => {
+  const iframe = document.querySelector("iframe");
+
+  // Load a document in the iframe
+  await new Promise((resolve) => {
+    iframe.onload = resolve;
+    iframe.src = "about:blank";
+  });
+
+  const iframeDocument = iframe.contentDocument;
+  const target = iframeDocument.createElement("div");
+  iframeDocument.body.appendChild(target);
+
+  t.add_cleanup(() => {
+    if (document.fullscreenElement) {
+      return document.exitFullscreen();
+    }
+  });
+
+  // Request fullscreen on the target element inside the iframe
+  await trusted_click(document.body);
+  await target.requestFullscreen();
+
+  await new Promise(resolve => {
+    if (document.fullscreenElement) resolve();
+    else document.addEventListener("fullscreenchange", resolve, {once: true});
+  });
+
+  assert_equals(document.fullscreenElement, iframe, "Parent document fullscreen element should be the iframe");
+
+  // Unload the iframe's document by navigating it
+  const secondEventPromise = fullScreenChange(document);
+  iframe.src = "about:blank?unloaded";
+
+  await secondEventPromise;
+
+  assert_equals(document.fullscreenElement, null, "Parent document should fully exit fullscreen");
+}, "When a document unloads, the unloading document cleanup steps must fully exit fullscreen for that document.");
+</script>

--- a/fullscreen/rendering/fullscreen-pseudo-class-shadow-host.html
+++ b/fullscreen/rendering/fullscreen-pseudo-class-shadow-host.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<title>:fullscreen pseudo-class on shadow host</title>
+<link rel="help" href="https://fullscreen.spec.whatwg.org/">
+<meta name="assert" content="The :fullscreen CSS pseudo-class must match any shadow host element if retargeting its node document's fullscreen element against the shadow host returns the shadow host itself.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="host"></div>
+<script>
+  promise_test(async (t) => {
+    t.add_cleanup(() => {
+      if (document.fullscreenElement) {
+        return document.exitFullscreen();
+      }
+    });
+
+    const host = document.getElementById("host");
+    const shadowRoot = host.attachShadow({ mode: "open" });
+    const inner = document.createElement("div");
+    shadowRoot.appendChild(inner);
+
+    // Request fullscreen for the inner element. We pass document.body
+    // to trusted_request to ensure the button is created in the light DOM
+    // where testdriver can reliably click it.
+    await trusted_request(inner, document.body);
+    await fullScreenChange();
+
+    assert_equals(document.fullscreenElement, host);
+    assert_equals(shadowRoot.fullscreenElement, inner);
+
+    assert_true(
+      inner.matches(":fullscreen"),
+      "inner:fullscreen in shadow DOM"
+    );
+    assert_true(
+      host.matches(":fullscreen"),
+      "host:fullscreen in shadow DOM due to retargeting"
+    );
+  }, "The :fullscreen CSS pseudo-class must match any shadow host element if retargeting its node document's fullscreen element against the shadow host returns the shadow host itself.");
+</script>


### PR DESCRIPTION
These tests are generated for the `fullscreen` Web Feature ID using WPT-Gen

Audit worksheet:
```
<audit_worksheet>
[Existence]
R1: The `Element` interface must support the `requestFullscreen` method. -> [COVERED by idlharness.window.js]
R2: The `Element` interface must support the `onfullscreenchange` event handler IDL attribute. -> [COVERED by idlharness.window.js]
R3: The `Element` interface must support the `onfullscreenerror` event handler IDL attribute. -> [COVERED by idlharness.window.js]
R4: The `Document` interface must support the `fullscreenEnabled` readonly attribute. -> [COVERED by idlharness.window.js]
R5: The `Document` interface must support the `fullscreen` readonly attribute. -> [COVERED by idlharness.window.js]
R6: The `Document` interface must support the `exitFullscreen` method. -> [COVERED by idlharness.window.js]
R7: The `Document` interface must support the `onfullscreenchange` event handler IDL attribute. -> [COVERED by idlharness.window.js]
R8: The `Document` interface must support the `onfullscreenerror` event handler IDL attribute. -> [COVERED by idlharness.window.js]
R9: The `DocumentOrShadowRoot` interface mixin must support the `fullscreenElement` readonly attribute. -> [COVERED by idlharness.window.js]
R10: The `ShadowRoot` object must not support the `onfullscreenchange` event handler IDL attribute. -> [COVERED by idlharness.window.js]
R11: The `ShadowRoot` object must not support the `onfullscreenerror` event handler IDL attribute. -> [COVERED by idlharness.window.js]
R12: The `Window` object must not support the `onfullscreenchange` event handler IDL attribute. -> [COVERED by idlharness.window.js]
R13: The `Window` object must not support the `onfullscreenerror` event handler IDL attribute. -> [COVERED by idlharness.window.js]
R14: The `Element` object must not support the `onfullscreenchange` event handler content attribute in any namespace. -> [UNCOVERED]
R15: The `Element` object must not support the `onfullscreenerror` event handler content attribute in any namespace. -> [UNCOVERED]

[Common Use Cases]
R16: The `document.fullscreenElement` attribute must return the topmost element in the document's top layer that has its fullscreen flag set, or null if no such element exists. -> [COVERED by document-fullscreen-element.html]
R17: When an element successfully enters fullscreen via `Element.requestFullscreen()`, the method must return a Promise that resolves with `undefined`. -> [COVERED by promises-resolve.html]
R18: A successful call to `Element.requestFullscreen()` must consume user activation. -> [COVERED by element-request-fullscreen-consume-user-activation.html]
R19: When an element successfully enters fullscreen, a `fullscreenchange` event must be appended to the document's list of pending fullscreen events. -> [COVERED by element-request-fullscreen.html]
R20: When `Element.requestFullscreen()` is successfully invoked on an `iframe` element, the element's iframe fullscreen flag must be set. -> [COVERED by element-ready-check-fullscreen-iframe-child.html]
R21: When `Document.exitFullscreen()` is called successfully, it must return a Promise that resolves with `undefined`. -> [COVERED by promises-resolve.html]
R22: When a document successfully exits fullscreen via `Document.exitFullscreen()`, a `fullscreenchange` event must be appended to the document's list of pending fullscreen events. -> [COVERED by document-exit-fullscreen.html]
R23: If the document's current fullscreen element is removed from the DOM, the document must automatically exit fullscreen. -> [COVERED by model/remove-single.html]
R24: When a document is unloaded, the unloading document cleanup steps must fully exit fullscreen for that document. -> [COVERED by element-request-fullscreen-and-remove-iframe.html]
R25: Fullscreen events (`fullscreenchange` and `fullscreenerror`) must be fired with their `bubbles` and `composed` attributes set to true. -> [COVERED by element-request-fullscreen.html]
R26: The `document.fullscreenEnabled` attribute must return true if the document is allowed to use the fullscreen feature and fullscreen is supported, and false otherwise. -> [COVERED by document-fullscreen-enabled.html]
R27: The `document.fullscreen` attribute must return true if the document's fullscreen element is not null, and false otherwise. -> [UNCOVERED]
R28: The `fullscreenElement` attribute on a `ShadowRoot` must return null if the shadow root's host is not connected. -> [UNCOVERED]
R29: The `Element` and `Document` interfaces must support the `onfullscreenchange` and `onfullscreenerror` event handler IDL attributes. -> [COVERED by idlharness.window.js]
[Common Use Cases]
R30: The `ShadowRoot` and `Window` interfaces must not support the `onfullscreenchange` and `onfullscreenerror` event handler IDL attributes. -> [COVERED by idlharness.window.js]
R31: The `:fullscreen` CSS pseudo-class must match any element that has its fullscreen flag set. -> [COVERED by fullscreen-pseudo-class.html]
R32: The `:fullscreen` CSS pseudo-class must match any element that is a shadow host where the retargeted fullscreen element is the host itself. -> [UNCOVERED]

[Error Scenarios]
R33: If `requestFullscreen()` is called and the element's node document is not fully active, the method must reject the returned promise with a `TypeError` exception. -> [COVERED by element-request-fullscreen-active-document.html]
R34: If `requestFullscreen()` is called on an element whose namespace is not the HTML namespace, and is not an SVG `svg` or MathML `math` element, it must append a `fullscreenerror` event to the document's list of pending fullscreen events and reject the promise with a `TypeError` exception. -> [COVERED by element-request-fullscreen-namespaces.html]
R35: If `requestFullscreen()` is called on a `dialog` element, it must append a `fullscreenerror` event to the document's list of pending fullscreen events and reject the promise with a `TypeError` exception. -> [COVERED by element-request-fullscreen-dialog.html]
R36: If `requestFullscreen()` is called on an element for which the fullscreen element ready check returns false, it must append a `fullscreenerror` event to the document's list of pending fullscreen events and reject the promise with a `TypeError` exception. -> [COVERED by element-ready-check-not-in-document.html]
R37: If `requestFullscreen()` is called when fullscreen is not supported, it must append a `fullscreenerror` event to the document's list of pending fullscreen events and reject the promise with a `TypeError` exception. -> [COVERED by element-request-fullscreen-not-allowed.html]
R38: If `requestFullscreen()` is called and the element's relevant global object lacks transient activation (and the algorithm is not triggered by a user generated orientation change), it must append a `fullscreenerror` event to the document's list of pending fullscreen events and reject the promise with a `TypeError` exception. -> [COVERED by element-request-fullscreen-without-user-activation.tentative.https.html]
R39: If `requestFullscreen()` is called and the element's node document changes to a different document before the parallel steps evaluate it, it must append a `fullscreenerror` event to the document's list of pending fullscreen events and reject the promise with a `TypeError` exception. -> [COVERED by element-request-fullscreen-and-move-to-iframe.html]
R40: If `exitFullscreen()` is called and the document is not fully active, the method must reject the returned promise with a `TypeError` exception. -> [COVERED by document-exit-fullscreen-active-document.html]
R41: If `exitFullscreen()` is called and the document's fullscreen element is null, the method must reject the returned promise with a `TypeError` exception. -> [COVERED by promises-reject.html]

[Invalidation]
R42: When a node is removed from the DOM, if any of its shadow-including inclusive descendants have their fullscreen flag set and the node is the document's fullscreen element, the document must exit fullscreen. -> [COVERED by remove-parent.html]
R43: When a node is removed from the DOM, if any of its shadow-including inclusive descendants have their fullscreen flag set but the node is not the document's fullscreen element, the node must be unfullscreened and removed from the top layer. -> [COVERED by remove-first-sibling.html]
R44: When a document unloads, the unloading document cleanup steps must fully exit fullscreen for that document. -> [COVERED by element-request-fullscreen-and-remove-iframe.html]
R45: If the fullscreenElement attribute is accessed on a shadow root whose host is not connected to the DOM, it must return null. -> [UNCOVERED]
R46: During the exit fullscreen algorithm, if the document's fullscreen element is no longer connected to the DOM, a fullscreenchange event must be queued and the element must be unfullscreened. -> [COVERED by remove-single.html]

[Integration]
R47: When an element is fullscreened, the user agent must run the "hide all popovers until" algorithm using the element's topmost popover ancestor. -> [UNCOVERED]
R48: When an element is fullscreened, the user agent must add the element to the document's top layer. -> [COVERED by fullscreen-reordering.html]
R49: When an element is unfullscreened, the user agent must immediately remove the element from the document's top layer. -> [COVERED by fullscreen-reordering.html]
R50: The requestFullscreen() method must reject its promise with a TypeError if the target element is an HTML dialog element. -> [COVERED by element-request-fullscreen-dialog.html]
R51: When requestFullscreen() successfully processes an iframe element, the user agent must set the element's iframe fullscreen flag. -> [COVERED by element-ready-check-fullscreen-iframe-child.html]
R52: When the "exit fullscreen" algorithm is run for a document, the user agent must execute the "fully unlock the screen orientation" steps for that document. -> [UNCOVERED]
R53: The :fullscreen CSS pseudo-class must match any element that has its fullscreen flag set. -> [COVERED by fullscreen-pseudo-class.html]
R54: The :fullscreen CSS pseudo-class must match any shadow host element if retargeting its node document's fullscreen element against the shadow host returns the shadow host itself. -> [UNCOVERED]
R55: The requestFullscreen() method must reject its promise with a TypeError if the element's node document is denied use of the "fullscreen" feature by the Permissions Policy. -> [COVERED by navigate-iframe.sub.html]
R56: The presence of the allowfullscreen attribute on an iframe element must be evaluated equivalently to an allow="fullscreen *" attribute for the document's Permissions Policy, unless explicitly overridden by an allow attribute. -> [COVERED by document-fullscreen-enabled-cross-origin.sub.html]
R57: If a user initiates an HTML close request, the user agent must trigger the "fully exit fullscreen" algorithm as part of the close request steps, taking precedence over any close watchers. -> [UNCOVERED]

```